### PR TITLE
4 add services

### DIFF
--- a/src/app/Hero.ts
+++ b/src/app/Hero.ts
@@ -1,4 +1,0 @@
-export interface Hero {
-  id: number;
-  name: string;
-}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
 <h1>{{ title }}</h1>
 <app-heroes></app-heroes>
+<app-messages></app-messages>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,9 +5,10 @@ import { FormsModule } from '@angular/forms';
 import { AppComponent } from './app.component';
 import { HeroesComponent } from './heroes/heroes.component';
 import { HeroDetailComponent } from './hero-detail/hero-detail.component';
+import { MessagesComponent } from './messages/messages.component';
 
 @NgModule({
-  declarations: [AppComponent, HeroesComponent, HeroDetailComponent],
+  declarations: [AppComponent, HeroesComponent, HeroDetailComponent, MessagesComponent],
   imports: [BrowserModule, FormsModule],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/hero-detail/hero-detail.component.ts
+++ b/src/app/hero-detail/hero-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Hero } from '../Hero';
+import { Hero } from '../hero';
 
 @Component({
   selector: 'app-hero-detail',

--- a/src/app/hero.service.spec.ts
+++ b/src/app/hero.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HeroService } from './hero.service';
+
+describe('HeroService', () => {
+  let service: HeroService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HeroService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/hero.service.ts
+++ b/src/app/hero.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+
+import { Observable, of } from 'rxjs';
+
+import { Hero } from './hero';
+import { HEROES } from './mock-heroes';
+import { MessageService } from './message.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HeroService {
+  constructor(private messageService: MessageService) {}
+
+  getHeroes(): Observable<Hero[]> {
+    const heroes = of(HEROES);
+    this.messageService.add('HeroService: fetched heroes');
+    return heroes;
+  }
+}

--- a/src/app/hero.ts
+++ b/src/app/hero.ts
@@ -1,0 +1,4 @@
+export interface Hero {
+  id: number;
+  name: string;
+}

--- a/src/app/heroes/heroes.component.ts
+++ b/src/app/heroes/heroes.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+
 import { Hero } from '../hero';
-import { HEROES } from '../mock-heroes';
+import { HeroService } from '../hero.service';
+import { MessageService } from '../message.service';
 
 @Component({
   selector: 'app-heroes',
@@ -8,14 +10,25 @@ import { HEROES } from '../mock-heroes';
   styleUrls: ['./heroes.component.css'],
 })
 export class HeroesComponent implements OnInit {
-  constructor() {}
-
-  heroes = HEROES;
-
   selectedHero?: Hero;
-  onSelect(hero: Hero): void {
-    this.selectedHero = hero;
+
+  heroes: Hero[] = [];
+
+  constructor(
+    private heroService: HeroService,
+    private messageService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.getHeroes();
   }
 
-  ngOnInit(): void {}
+  onSelect(hero: Hero): void {
+    this.selectedHero = hero;
+    this.messageService.add(`HeroesComponent: Selected hero id=${hero.id}`);
+  }
+
+  getHeroes(): void {
+    this.heroService.getHeroes().subscribe((heroes) => (this.heroes = heroes));
+  }
 }

--- a/src/app/message.service.spec.ts
+++ b/src/app/message.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MessageService } from './message.service';
+
+describe('MessageService', () => {
+  let service: MessageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MessageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/message.service.ts
+++ b/src/app/message.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MessageService {
+  messages: string[] = [];
+
+  add(message: string) {
+    this.messages.push(message);
+  }
+
+  clear() {
+    this.messages = [];
+  }
+
+  constructor() {}
+}

--- a/src/app/messages/messages.component.css
+++ b/src/app/messages/messages.component.css
@@ -1,0 +1,19 @@
+/* MessagesComponent's private CSS styles */
+h2 {
+  color: #a80000;
+  font-family: Arial, Helvetica, sans-serif;
+  font-weight: lighter;
+}
+
+.clear {
+  color: #333;
+  background-color: #eee;
+  margin-bottom: 12px;
+  padding: 1rem;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+.clear:hover {
+  color: white;
+  background-color: #42545c;
+}

--- a/src/app/messages/messages.component.html
+++ b/src/app/messages/messages.component.html
@@ -1,0 +1,7 @@
+<div *ngIf="messageService.messages.length">
+  <h2>Messages</h2>
+  <button type="button" class="clear" (click)="messageService.clear()">
+    Clear Message
+  </button>
+  <div *ngFor="let message of messageService.messages">{{ message }}</div>
+</div>

--- a/src/app/messages/messages.component.spec.ts
+++ b/src/app/messages/messages.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MessagesComponent } from './messages.component';
+
+describe('MessagesComponent', () => {
+  let component: MessagesComponent;
+  let fixture: ComponentFixture<MessagesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MessagesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MessagesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/messages/messages.component.ts
+++ b/src/app/messages/messages.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+import { MessageService } from '../message.service';
+
+@Component({
+  selector: 'app-messages',
+  templateUrl: './messages.component.html',
+  styleUrls: ['./messages.component.css'],
+})
+export class MessagesComponent implements OnInit {
+  constructor(public messageService: MessageService) {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/mock-heroes.ts
+++ b/src/app/mock-heroes.ts
@@ -1,4 +1,4 @@
-import { Hero } from './Hero';
+import { Hero } from './hero';
 
 export const HEROES: Hero[] = [
   { id: 11, name: 'Dr Nice' },


### PR DESCRIPTION
Finished the fourth section of Tour of Heroes, accomplishing the following items:

- Refactored data access to the HeroService class
- Registered the HeroService as the provider of its service at the root level so that it can be injected anywhere in the application
- Esed Angular Dependency Injection to inject it into a component
- Gave the HeroService get data method an asynchronous signature
- Discovered Observable and the RxJS Observable library
- Used RxJS of() to return an observable of mock heroes (Observable<Hero[]>)
- The component's ngOnInit lifecycle hook calls the HeroService method, not the constructor
- Created a MessageService for loosely-coupled communication between classes
- The HeroService injected into a component is created with another injected service, MessageService